### PR TITLE
fix save_with_state_error

### DIFF
--- a/test/statesman/multi_state/active_record_macro_test.rb
+++ b/test/statesman/multi_state/active_record_macro_test.rb
@@ -75,6 +75,24 @@ module Statesman
         assert_equal 1, AdminStatusOrderTransition.count
       end
 
+      test 'save_with_state returns false and adds errors if the transition is invalid' do
+        order = Order.create
+        order.user_status_state_form = 'invalid_state'
+        assert_equal false, order.save_with_state
+        assert order.errors.any?, 'Expected errors to be present'
+        assert_includes order.errors.full_messages, 'User status cannot transition from user_pending to invalid_state'
+      end
+
+      test 'save_with_state does not error when setting the same state as current' do
+        order = Order.create
+        current_state = order.user_status_current_state
+
+        order.user_status_state_form = current_state
+        assert order.save_with_state, 'Expected save_with_state to return true'
+        assert_empty order.errors, 'Expected no errors'
+        assert_equal current_state, order.user_status_current_state
+      end
+
       test 'sets an Reflection::HasOneStateMachineReflection and yield it to a block if given' do
         result = nil
         klass = build_ar_klass


### PR DESCRIPTION
Hi Ched,

The purpose of this PR is to fix save_with_state since it returns true when a transition is invalid
In my use case if an operator tries to transition payment procedure from canceled to to_process), it silently fails since no @registered_callbacks gets registered then no transition is operated which I think is misleading the operator.

we can add an error if the transition is not possible but further fixes are needed :

1. need to define private reader method `def #{field_name}` because it is needed by active record full_messages method
2. Important. : this line if #{virtual_attribute_name}_changed? didnt work as expected. It always return true because Rails sees this as a change from nil → 'canceled', even though the effective value is the same. We need {virtual_attribute_name}.to_s != #{field_name}_current_state.to_s to check that state didnt change. In Sidecare some forms submit the current_state_value (payment procedure for instance) and without this proper check, these forms will always fail to update the instances

Hope you like it

