### PR TITLE
Reset memoized state machines on reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.8] - 2026-02-06
+  - Reset memoized state machines on `reload` so `current_state` is not stale after
+    concurrent updates.
+
 ## [0.2.7] - 2026-01-21
   - Fix `save_with_state` false negative always returning true even when the
     transition is invalid.

--- a/lib/statesman/adapters/custom_active_record_queries.rb
+++ b/lib/statesman/adapters/custom_active_record_queries.rb
@@ -27,7 +27,15 @@ module Statesman
 
           define_in_state(base, query_builder, join_name, field_name)
           define_not_in_state(base, query_builder, join_name, field_name)
-        end
+
+          define_method(:reload) do |*a|
+            instance = super(*a)
+            if instance.respond_to?(:"#{field_name}_state_machine", true)
+              instance.send(:"#{field_name}_state_machine").reset
+            end
+            instance
+          end
+       end
 
         private
 

--- a/lib/statesman/multi_state/version.rb
+++ b/lib/statesman/multi_state/version.rb
@@ -2,6 +2,6 @@
 
 module Statesman
   module MultiState
-    VERSION = '0.2.7'
+    VERSION = '0.2.8'
   end
 end

--- a/test/statesman/multi_state/active_record_macro_test.rb
+++ b/test/statesman/multi_state/active_record_macro_test.rb
@@ -75,6 +75,28 @@ module Statesman
         assert_equal 1, AdminStatusOrderTransition.count
       end
 
+      test 'reload resets state machines so current_state reflects DB changes from another instance' do
+        order = Order.create!
+
+        # Prime memoized state machine instances (they persist across `reload`)
+        assert_equal :user_pending, order.user_status_current_state.to_sym
+        assert_equal :admin_pending, order.admin_status_current_state.to_sym
+
+        # Load a separate instance for the same DB row to simulate a concurrent updater
+        other = Order.find(order.id)
+        other.user_status_transition_to!(:processed)
+        other.admin_status_transition_to!(:validated)
+
+        # Prove the cache is stale without an explicit reset
+        assert_equal :user_pending, order.user_status_current_state.to_sym
+        assert_equal :admin_pending, order.admin_status_current_state.to_sym
+
+        order.reload
+
+        assert_equal :processed, order.user_status_current_state.to_sym
+        assert_equal :validated, order.admin_status_current_state.to_sym
+      end
+
       test 'sets an Reflection::HasOneStateMachineReflection and yield it to a block if given' do
         result = nil
         klass = build_ar_klass


### PR DESCRIPTION
Ensure ActiveRecord#reload clears cached Statesman transitions so current_state reflects concurrent updates. Adds regression test and bumps version to 0.2.8.