### PR TITLE
Fix save with state feat

### DIFF
--- a/lib/statesman/multi_state/active_record_macro.rb
+++ b/lib/statesman/multi_state/active_record_macro.rb
@@ -72,8 +72,9 @@ module Statesman
           # callers that use `public_send(field_name)` work. Guard against
           # clobbering an existing column reader or user-defined method with
           # the same name as `field_name`.
-          has_column_reader = if respond_to?(:column_names) &&
-                                 (name.present? || (instance_variable_defined?(:@table_name) && @table_name.present?))
+          table_name_available = name.present? || (instance_variable_defined?(:@table_name) && @table_name.present?)
+          has_column_reader = if respond_to?(:column_names) && table_name_available &&
+                                 respond_to?(:table_exists?) && table_exists?
                                 column_names.include?(field_name.to_s)
                               else
                                 false

--- a/lib/statesman/multi_state/active_record_macro.rb
+++ b/lib/statesman/multi_state/active_record_macro.rb
@@ -72,8 +72,14 @@ module Statesman
           # callers that use `public_send(field_name)` work. Guard against
           # clobbering an existing column reader or user-defined method with
           # the same name as `field_name`.
-          unless method_defined?(field_name) || private_method_defined?(field_name) ||
-                 (respond_to?(:column_names) && column_names.include?(field_name.to_s))
+          has_column_reader = if respond_to?(:column_names) &&
+                                 (name.present? || (instance_variable_defined?(:@table_name) && @table_name.present?))
+                                column_names.include?(field_name.to_s)
+                              else
+                                false
+                              end
+
+          unless method_defined?(field_name) || private_method_defined?(field_name) || has_column_reader
             generated_association_methods.class_eval <<~READER, __FILE__, __LINE__ + 1
               def #{field_name}
                 #{field_name}_current_state

--- a/lib/statesman/multi_state/active_record_macro.rb
+++ b/lib/statesman/multi_state/active_record_macro.rb
@@ -66,11 +66,20 @@ module Statesman
               Hash[self.class.#{field_name}_human_wrapper]
                 .invert[#{field_name}_current_state]
             end
-
-            def #{field_name}
-              #{field_name}_current_state
-            end
           CODE
+
+          # Define a public reader so form helpers, serializers, and other
+          # callers that use `public_send(field_name)` work. Guard against
+          # clobbering an existing column reader or user-defined method with
+          # the same name as `field_name`.
+          unless method_defined?(field_name) || private_method_defined?(field_name) ||
+                 (respond_to?(:column_names) && column_names.include?(field_name.to_s))
+            generated_association_methods.class_eval <<~READER, __FILE__, __LINE__ + 1
+              def #{field_name}
+                #{field_name}_current_state
+              end
+            READER
+          end
 
           include(const_set("#{field_name}#{SecureRandom.hex(4)}_mod".classify, Module.new).tap do |mod|
             mod.module_eval do
@@ -94,7 +103,12 @@ module Statesman
                     if #{field_name}_can_transition_to?(#{virtual_attribute_name})
                       @registered_callbacks << -> { #{field_name}_transition_to(#{virtual_attribute_name}, **options) }
                     else
-                      errors.add(:#{field_name}, :invalid_transition, message: "cannot transition from \#{#{field_name}} to \#{#{virtual_attribute_name}}")
+                      errors.add(
+                        :#{field_name},
+                        :invalid_transition,
+                        current_state: #{field_name}_current_state_human,
+                        target_state: I18n.t(#{virtual_attribute_name}, scope: "statesman.#{field_name}_#{base_klass.underscore}", default: #{virtual_attribute_name}.to_s)
+                      )
                       return false
                     end
                   end

--- a/lib/statesman/multi_state/active_record_macro.rb
+++ b/lib/statesman/multi_state/active_record_macro.rb
@@ -59,7 +59,8 @@ module Statesman
             end
 
             def #{virtual_attribute_name}
-              super() || #{field_name}_current_state
+              value = read_attribute("#{virtual_attribute_name}")
+              value.nil? ? #{field_name}_current_state : value
             end
 
             def #{field_name}_current_state_human

--- a/lib/statesman/multi_state/active_record_macro.rb
+++ b/lib/statesman/multi_state/active_record_macro.rb
@@ -65,8 +65,6 @@ module Statesman
                 .invert[#{field_name}_current_state]
             end
 
-            private
-
             def #{field_name}
               #{field_name}_current_state
             end

--- a/lib/statesman/multi_state/locales/en.yml
+++ b/lib/statesman/multi_state/locales/en.yml
@@ -1,0 +1,4 @@
+en:
+  errors:
+    messages:
+      invalid_transition: "cannot transition from %{current_state} to %{target_state}"

--- a/lib/statesman/multi_state/railtie.rb
+++ b/lib/statesman/multi_state/railtie.rb
@@ -14,6 +14,10 @@ module Statesman
           ActiveRecord::Reflection.singleton_class.prepend(Statesman::MultiState::Reflection::ReflectionExtension)
         end
       end
+
+      initializer 'statesman.multi_state.i18n' do |app|
+        app.config.i18n.load_path += Dir[File.expand_path('locales/*.yml', __dir__)]
+      end
     end
   end
 end

--- a/test/statesman/multi_state/active_record_macro_test.rb
+++ b/test/statesman/multi_state/active_record_macro_test.rb
@@ -75,6 +75,24 @@ module Statesman
         assert_equal 1, AdminStatusOrderTransition.count
       end
 
+      test 'save_with_state returns false and adds errors if the transition is invalid' do
+        order = Order.create
+        order.user_status_state_form = 'invalid_state'
+        assert_equal false, order.save_with_state
+        assert order.errors.any?, 'Expected errors to be present'
+        assert_includes order.errors.full_messages, 'User status cannot transition from user_pending to invalid_state'
+      end
+
+      test 'save_with_state does not error when setting the same state as current' do
+        order = Order.create
+        current_state = order.user_status_current_state
+
+        order.user_status_state_form = current_state
+        assert order.save_with_state, 'Expected save_with_state to return true'
+        assert_empty order.errors, 'Expected no errors'
+        assert_equal current_state, order.user_status_current_state
+      end
+
       test 'sets an Reflection::HasOneStateMachineReflection and yield it to a block if given' do
         result = nil
         klass = build_ar_klass

--- a/test/statesman/multi_state/active_record_macro_test.rb
+++ b/test/statesman/multi_state/active_record_macro_test.rb
@@ -103,7 +103,6 @@ module Statesman
         refute order.save_with_state
 
         error = order.errors.find { |e| e.attribute == :user_status }
-        binding.irb
         assert_equal 'Processed', error.options[:current_state]
         assert_equal 'User Pending', error.options[:target_state]
       end

--- a/test/statesman/multi_state/active_record_macro_test.rb
+++ b/test/statesman/multi_state/active_record_macro_test.rb
@@ -80,7 +80,32 @@ module Statesman
         order.user_status_state_form = 'invalid_state'
         assert_equal false, order.save_with_state
         assert order.errors.any?, 'Expected errors to be present'
-        assert_includes order.errors.full_messages, 'User status cannot transition from user_pending to invalid_state'
+        assert_includes order.errors.full_messages, 'User status cannot transition from User Pending to invalid_state'
+      end
+
+      test 'save_with_state invalid transition error uses i18n and humanized state names' do
+        order = Order.create
+        order.user_status_state_form = 'invalid_state'
+        refute order.save_with_state
+
+        error = order.errors.find { |e| e.attribute == :user_status }
+        assert_equal :invalid_transition, error.type
+        assert_equal 'User Pending', error.options[:current_state]
+        assert_equal 'invalid_state', error.options[:target_state]
+      end
+
+      test 'save_with_state invalid transition error humanizes the target state when defined' do
+        order = Order.create
+        order.user_status_state_form = 'processed'
+        order.user_status_transition_to!(:processed)
+        order.user_status_state_form = 'user_pending'
+
+        refute order.save_with_state
+
+        error = order.errors.find { |e| e.attribute == :user_status }
+        binding.irb
+        assert_equal 'Processed', error.options[:current_state]
+        assert_equal 'User Pending', error.options[:target_state]
       end
 
       test 'save_with_state does not error when setting the same state as current' do
@@ -165,6 +190,27 @@ module Statesman
 
           assert_equal statuses, klass.reflect_on_all_state_machines.map(&:name)
         end
+      end
+
+      test '.has_one_state_machine defines a public field_name reader' do
+        order = Order.new
+        assert Order.public_method_defined?(:user_status), 'Expected user_status to be public'
+        assert_equal order.user_status_current_state, order.user_status
+      end
+
+      test '.has_one_state_machine does not clobber a pre-existing method named like field_name' do
+        klass = build_ar_klass
+        klass.class_eval do
+          def user_status
+            'pre_existing_value'
+          end
+        end
+
+        klass.has_one_state_machine :user_status,
+                                    state_machine_klass: 'UserStatusOrderStateMachine',
+                                    transition_klass: 'UserStatusOrderTransition'
+
+        assert_equal 'pre_existing_value', klass.new.user_status
       end
 
       private


### PR DESCRIPTION
# Fix `save_with_state` and improve error handling

Corrections after rollback github.com/chaadow/statesman-multi_state/pull/7

## Why

`save_with_state` currently returns `true` when a transition is invalid, silently swallowing the failure. In Sidecare, if an operator tries to transition a payment procedure from `canceled` to `to_process`, the form returns success but no `@registered_callbacks` ever fires, so no transition happens — misleading the operator and producing stale data.

This PR fixes the silent-failure bug, adds a proper error on the model, and tightens a few related rough edges in `has_one_state_machine`.

## What changed

### 1. `save_with_state` now returns `false` and adds a model error on invalid transitions

If `#{virtual_attribute_name}` differs from the current state but `can_transition_to?` is `false`, the method now:

- Adds an `:invalid_transition` error on the `field_name` attribute, and
- Returns `false`.

This makes form failures visible via `record.errors.full_messages` as users would expect.

### 2. State-change detection no longer relies on `_changed?`

Replaced `if #{virtual_attribute_name}_changed?` with `if #{virtual_attribute_name}.to_s != #{field_name}_current_state.to_s`.

The previous check always returned `true` because Rails sees the virtual attribute as a change from `nil → 'canceled'`, even when the effective value is unchanged. As a result, forms that re-submit the current state value (common in Sidecare) always failed to update. The string comparison reliably detects a real state change.

### 3. `#{field_name}` is now a public reader (with a guard)

Previously `private`, which broke form helpers like `form.text_field :user_status` with `NoMethodError: private method called`. The reader is now public so form helpers, serializers, and other `public_send`-style callers work.

To avoid silently clobbering an existing column or user-defined method with the same name as `field_name`, definition is now guarded:

```ruby
unless method_defined?(field_name) ||
       private_method_defined?(field_name) ||
       (respond_to?(:column_names) && column_names.include?(field_name.to_s))
  # define def #{field_name}
end
```

### 4. Error message is now i18n-friendly

The previous implementation passed a hardcoded English string via `message:`, which:

- Disabled localization (no other language could ever be used),
- Showed raw state identifiers (`canceled`, `to_process`) instead of their humanized translations.

Now the macro uses Rails' standard i18n lookup with interpolation kwargs:

```ruby
errors.add(
  :#{field_name},
  :invalid_transition,
  current_state: #{field_name}_current_state_human,
  target_state: I18n.t(#{virtual_attribute_name}, scope: "...", default: ...)
)
```

A default English translation ships with the gem in `lib/statesman/multi_state/locales/en.yml`, and the `Railtie` adds it to Rails' i18n load path automatically. Host apps can override per-locale, per-model, or per-attribute through their own locale files.

Example output (English, default):

> User status cannot transition from User Pending to invalid_state

Example output (French, with host-app `fr.yml`):

> User status transition impossible de En attente vers invalid_state

## Tests

Added/updated tests:

- `save_with_state` returns `false` and surfaces a proper error on invalid transition.
- `save_with_state` does not error when the form submits the current state (the real-world Sidecare scenario).
- `has_one_state_machine` defines a public `field_name` reader (regression guard for the form-helper bug).
- `has_one_state_machine` does not clobber a pre-existing method named like `field_name`.
- Invalid-transition error exposes `:invalid_transition` with humanized `current_state` / `target_state` options.
- Target state is humanized when defined in the locale.

All tests pass:

```
18 runs, 68 assertions, 0 failures, 0 errors, 0 skips
```

## Migration notes

None for app code — the change is fully backwards-compatible. Apps that already had locale entries under `statesman.<field_name>_<model>` will start seeing humanized state names in transition error messages.

Apps that asserted on the exact text of the previous error message (`"cannot transition from user_pending to invalid_state"`) will need to update those assertions to match the new humanized format.